### PR TITLE
Moving README and LICENSE files under the tools folder.

### DIFF
--- a/onebuild.nuspec
+++ b/onebuild.nuspec
@@ -23,6 +23,7 @@
     <file src="tools\**\*.*" target="\tools\" />
 	<file src="OneBuild.build.ps1" target="\tools\temp\" />
 	<file src="Build.bat" target="\tools\temp\" />	
+	<file src="OneBuild.bat" target="\tools\temp\" />		
 	<file src="LICENSE" target="\tools\LICENSE" />
 	<file src="README.MD" target="\tools\README.MD" />
   </files>  


### PR DESCRIPTION
Although not strictly required all packages seem to include their README and LICENSE files under the tools folder.
Also minor fix to NuGet package to include OneBuild.bat file
