### PR TITLE
25 The New-NuGetPackages module now throws an exception on failure. 

### DIFF
--- a/OneBuild.build.ps1
+++ b/OneBuild.build.ps1
@@ -50,20 +50,27 @@ task Invoke-Commit Invoke-Compile, Invoke-UnitTests, New-Packages, {
 #=================================================================================================
 task New-Packages Set-VersionNumber, {
 
-	if ($assemblyInformationalVersion -ne "")
-	{
-		$versionLabels = $assemblyInformationalVersion.Split(".")
-		$nuGetPackageVersion = $versionLabels[0] + "." + $versionLabels[1] + "." + $versionLabels[2]
-	}
-	else
-	{
-		$nuGetPackageVersion = "$major.$minor.$buildCounter"
-	}
+	try {
+		if ($assemblyInformationalVersion -ne "")
+		{
+			$versionLabels = $assemblyInformationalVersion.Split(".")
+			$nuGetPackageVersion = $versionLabels[0] + "." + $versionLabels[1] + "." + $versionLabels[2]
+		}
+		else
+		{
+			$nuGetPackageVersion = "$major.$minor.$buildCounter"
+		}
 
-	Write-Output "Will use version: $nuGetPackageVersion to build NuGet package"
-	Import-Module "$baseModulePath\New-NuGetPackages.psm1"
-	New-NuGetPackages -versionNumber $nuGetPackageVersion
-	Remove-Module New-NuGetPackages
+		Write-Output "Will use version: $nuGetPackageVersion to build NuGet package"
+		Import-Module "$baseModulePath\New-NuGetPackages.psm1"
+		New-NuGetPackages -versionNumber $nuGetPackageVersion
+	}
+	catch {
+		throw
+	}
+	finally {
+		Remove-Module New-NuGetPackages
+	}	
 }
 
 #=================================================================================================

--- a/tests/New-NuGetPackages.Tests.ps1
+++ b/tests/New-NuGetPackages.Tests.ps1
@@ -17,10 +17,9 @@ Describe "New-NuGetPackages_1" {
 		Mock -ModuleName $sut Write-Warning {} -Verifiable -ParameterFilter {
             $Message -eq "No NuGet '.nuspec' file found matching the packaging naming convention, exiting without NuGet packaging."
         }
-		
-		$result = 0
+
 		try {
-			$result = New-NuGetPackages -versionNumber "1.0.0"
+			New-NuGetPackages -versionNumber "1.0.0"
 		}
 		catch {
 			throw
@@ -36,10 +35,6 @@ Describe "New-NuGetPackages_1" {
 		It "Write a descriptive warning" {
 			Assert-VerifiableMocks
 		}
-
-        It "Exit module with code 0" {
-            $result | Should Be 0
-        }		
 	}	
 	
 	Context "When there is one NuSpec file" {
@@ -47,10 +42,9 @@ Describe "New-NuGetPackages_1" {
 		Import-Module "$baseModulePath\$sut"
 		Mock -ModuleName $sut Get-AllNuSpecFiles {return @("one.nuspec")} -Verifiable
 		Mock -ModuleName $sut Invoke-NuGetPack {return 0} -Verifiable
-		
-		$result = 0
+
 		try {
-			$result = New-NuGetPackages -versionNumber "1.0.0"
+			New-NuGetPackages -versionNumber "1.0.0"
 		}
 		catch {
 			throw
@@ -65,9 +59,6 @@ Describe "New-NuGetPackages_1" {
 		It "Should call Invoke-NuGetPack once to generate NuGet package" {
             Assert-MockCalled Invoke-NuGetPack -ModuleName $sut -Times 1
         }
-        It "Exits module with code 0" {
-			$result | Should Be 0
-        }		
 	}
 	
 	Context "When includeSymbolsPackage switch parameter is passed" {
@@ -76,9 +67,8 @@ Describe "New-NuGetPackages_1" {
 		Mock -ModuleName $sut Get-AllNuSpecFiles {return @("one.nuspec")} -Verifiable
 		Mock -ModuleName $sut Invoke-NuGetPackWithSymbols {return 0} -Verifiable
 		
-		$result = 0
 		try {
-			$result = New-NuGetPackages -versionNumber "1.0.0" -includeSymbolsPackage
+			New-NuGetPackages -versionNumber "1.0.0" -includeSymbolsPackage
 		}
 		catch {
 			throw
@@ -90,9 +80,6 @@ Describe "New-NuGetPackages_1" {
 		It "Should call Invoke-NuGetPackWithSymbols to generate NuGet and Symbols package" {
             Assert-MockCalled Invoke-NuGetPackWithSymbols -ModuleName $sut -Times 1
         }
-        It "Exits module with code 0" {
-            $result | Should Be 0
-        }		
 	}
 
 	Context "When there is an error generating a NuGet package" {
@@ -108,23 +95,19 @@ Describe "New-NuGetPackages_1" {
             $Object -like "Attempting to build package from 'test_error.nuspec'. Root element is missing."
         }		
 		
-		$result = 0
+		$result = ""
 		try {
 			$result = New-NuGetPackages -versionNumber "1.0.0" -path $testBasePath
 		}
 		catch {
-			throw
+			$result = $_
 		}
 		finally {
 			Remove-Module $sut
 		}
-
-		It "Should return a meaningful error message and write output to host" {
-			Assert-VerifiableMocks
-		}
 		
-        It "Exits module with code 1" {
-            $result | Should Be 1
+        It "Exits the module with a descriptive terminating error" {
+            $result | Should Match "An unexpected error occurred whilst executing Nuget Pack for the .nuspec file"
         }		
 	}		
 }
@@ -135,9 +118,8 @@ Describe "New-NuGetPackages_2" {
 		Mock -ModuleName $sut Get-AllNuSpecFiles {return @("one.nuspec", "two.nuspec")}
 		Mock -ModuleName $sut Invoke-NuGetPack {} 
 		
-		$result = 0
 		try {
-			$result = New-NuGetPackages -versionNumber "1.0.0"
+			New-NuGetPackages -versionNumber "1.0.0"
 		}
 		catch {
 			throw
@@ -150,9 +132,6 @@ Describe "New-NuGetPackages_2" {
             Assert-MockCalled Invoke-NuGetPack -ModuleName $sut -Times 2
         }
 
-        It "Exits module with code 0" {
-            $result | Should Be 0
-        }		
 	}	
 	
 }

--- a/tools/powershell/modules/New-NuGetPackages.psm1
+++ b/tools/powershell/modules/New-NuGetPackages.psm1
@@ -52,7 +52,6 @@ function New-NuGetPackages{
 				if ($specFilePaths -eq $null)
 				{
 					Write-Warning "No NuGet '.nuspec' file found matching the packaging naming convention, exiting without NuGet packaging."
-					return 0
 				}
 				
 				if ((Test-Path -Path "$basePath\BuildOutput") -eq $False) 
@@ -78,16 +77,14 @@ function New-NuGetPackages{
 						
 						if ($result) 
 						{
-							Write-Error "Whilst executing NuGet Pack on spec file $specFilePath, NuGet.exe exited with error message: $result"
-							Return 1
+							throw "An error occurred whilst executing Nuget Pack for the .nuspec file: $specFilePath. Nuget.exe exited with error message: $result"
+							
 						}
 					}
 					
-					Return 0
 				}
 				catch [Exception] {
-					throw "Error executing NuGet Pack for supplied spec file: $specFilePath using NuGet from: $nuGetPath `r`n $_.Exception.ToString()"
-					Return 1
+					throw "An unexpected error occurred whilst executing Nuget Pack for the .nuspec file: $specFilePath. Nuget.exe path: $nuGetPath nuget.exe. Nuget.exe exited with error message: `r`n $_"
 				}
 		}
 }


### PR DESCRIPTION
Fixing #25 - The New-NuGetPackages module now throws an exception on failure. Invoke-Build script re-throws, terminating the build if NuGet pack fails.