### PR TITLE
Format MSBuild output to include newlines in order to improve readabilit...

### DIFF
--- a/tools/powershell/modules/New-CompiledSolution.psm1
+++ b/tools/powershell/modules/New-CompiledSolution.psm1
@@ -147,7 +147,7 @@ function Invoke-MsBuildCompilationForSolution {
 			[string]$configMode				
 	)
 	Write-Warning "Building '$($solutionFile)' in '$($configMode)' mode"
-	$output = & $msbuildPath $solutionFile /t:ReBuild /t:Clean /p:Configuration=$configMode /p:PlatformTarget=AnyCPU /m 2>&1 
+	$output = (& $msbuildPath $solutionFile /t:ReBuild /t:Clean /p:Configuration=$configMode /p:PlatformTarget=AnyCPU /m 2>&1) -join "`r`n"
 	
 	#$err = $output | ? {$_.GetType().Name -eq "ErrorRecord"}
 	


### PR DESCRIPTION
This just makes the build output that bit easier to read when there are warnings and errors you may be interested in.