### PR TITLE
RunOctoPack=true specified when compiling the solution

### DIFF
--- a/tools/powershell/modules/New-CompiledSolution.psm1
+++ b/tools/powershell/modules/New-CompiledSolution.psm1
@@ -147,7 +147,7 @@ function Invoke-MsBuildCompilationForSolution {
 			[string]$configMode				
 	)
 	Write-Warning "Building '$($solutionFile)' in '$($configMode)' mode"
-	$output = & $msbuildPath $solutionFile /t:ReBuild /t:Clean /p:Configuration=$configMode /p:PlatformTarget=AnyCPU /m 2>&1 
+	$output = & $msbuildPath $solutionFile /t:ReBuild /t:Clean /p:Configuration=$configMode /p:RunOctoPack=true /p:PlatformTarget=AnyCPU /m 2>&1 
 	
 	#$err = $output | ? {$_.GetType().Name -eq "ErrorRecord"}
 	


### PR DESCRIPTION
This enables one build to support projects with the OcotoPack target installed. It is a potential solution to providing a convention based approach to generated nuget packages.

In addition to this flag, we probably don't want to run the current New-Packages task, but not 100% sure on this, perhaps both are useful to have. The convention can be: 

solution level nuspec, then custom package output in BuildOutput
no solution level nuspect but octopack target in csproj, then ocotopacked output in obj.