### PR TITLE
24 notifications being treated as warnings

### DIFF
--- a/OneBuild.build.ps1
+++ b/OneBuild.build.ps1
@@ -12,7 +12,9 @@ param(
 	$buildCounter = "999"
 )
 
-$DebugPreference = "Continue"
+$DebugPreference = "SilentlyContinue"
+#$VerbosePreference = "SilentlyContinue"
+$WarningPreference = "Continue"
 
 if ((Test-Path -path "$BuildRoot\tools\powershell\modules" ) -eq $True)
 {

--- a/tests/New-CompiledSolution.Tests.ps1
+++ b/tests/New-CompiledSolution.Tests.ps1
@@ -15,7 +15,7 @@ Describe "New-CompiledSolution" {
 		Mock -ModuleName $sut Get-FirstSolutionFile { return "solution.sln"}
 		Mock -ModuleName $sut Restore-SolutionNuGetPackages { }
 		Mock -ModuleName $sut Invoke-MsBuildCompilationForSolution { }
-		Mock -ModuleName $sut Write-Warning {} -Verifiable -ParameterFilter {
+		Mock -ModuleName $sut Write-Verbose {} -Verifiable -ParameterFilter {
             $Message -eq "Using Configuration mode 'Release'. Modify this by passing in a value for the parameter '-configMode'"
         }
 		
@@ -38,7 +38,7 @@ Describe "New-CompiledSolution" {
             Assert-MockCalled Invoke-MsBuildCompilationForSolution -ModuleName $sut -Times 1
         }	
 
-		It "Should write a descriptive warning about configuration mode" {
+		It "Should write a descriptive verbose message about configuration mode" {
 			Assert-VerifiableMocks 
 		}	
 	}


### PR DESCRIPTION
The following provides improved modules that use Write-Verbose and the introduction of a -verbose parameter that can be passed in to OneBuild.bat like so.

`C:\PS>.\OneBuild.bat -verbose

Giving the following kind of output (shown running OneBuild unit tests as an example)

![image](https://cloud.githubusercontent.com/assets/362197/6104868/4d235078-b049-11e4-9921-f9da71d4be38.png)

