### PR TITLE
Run octo pack

### DIFF
--- a/OneBuild.build.ps1
+++ b/OneBuild.build.ps1
@@ -13,8 +13,12 @@ param(
 )
 
 $DebugPreference = "SilentlyContinue"
-#$VerbosePreference = "SilentlyContinue"
 $WarningPreference = "Continue"
+
+if ($PSBoundParameters.ContainsKey('Verbose'))
+{
+	$VerbosePreference = "Continue"
+}
 
 if ((Test-Path -path "$BuildRoot\tools\powershell\modules" ) -eq $True)
 {
@@ -96,7 +100,7 @@ task Invoke-Compile Invoke-HardcoreClean, Set-VersionNumber, {
 		New-CompiledSolution -configMode $configuration
 	}
 	catch {
-		throw
+		throw $_
 	}
 	finally {
 		Remove-Module New-CompiledSolution
@@ -122,14 +126,14 @@ task Read-MajorMinorVersionNumber -If { ($major -eq $null) -and ($minor -eq $nul
 	{
 		#Retrieve the [major] and [minor] version numbers from the $($versionNumberFileName) file
 		[xml]$x = Get-Content "$BuildRoot\$($versionNumberFileName)"
-		Write-Warning "$($versionNumberFileName) file found, reading to set [major] and [minor] version numbers."
+		Write-Output "$($versionNumberFileName) file found, reading to set [major] and [minor] version numbers."
 		$script:major = $x.version.major
-		Write-Warning "Setting [major] version number to: $($script:major)."
+		Write-Output "Setting [major] version number to: $($script:major)."
 		$script:minor = $x.version.minor
-		Write-Warning "Setting [minor] version number to: $($script:minor)."
+		Write-Output "Setting [minor] version number to: $($script:minor)."
 
 	}else{
-		Write-Error "No $BuildRoot\$($versionNumberFileName) file found. Maybe you've forgotten to check it in?"
+		throw "No $BuildRoot\$($versionNumberFileName) file found. Maybe you've forgotten to check it in?"
 	}
 }
 

--- a/tools/powershell/modules/New-CompiledSolution.psm1
+++ b/tools/powershell/modules/New-CompiledSolution.psm1
@@ -44,7 +44,7 @@ function New-CompiledSolution{
 			$DebugPreference = "Continue"
 			if (-not $PSBoundParameters.ContainsKey('Verbose'))
 			{
-			$VerbosePreference = $PSCmdlet.GetVariableValue('VerbosePreference')
+				$VerbosePreference = $PSCmdlet.GetVariableValue('VerbosePreference')
 			}
 		}	
 	Process {
@@ -75,7 +75,6 @@ function New-CompiledSolution{
 					{
 						throw "Whilst executing MsBuild for solution file $solutionFile, MsBuild.exe exited with error message: $result"
 					}
-				
 				}
 				catch [Exception] {
 					throw "Error compiling solution file: $solutionFile. `r`n $_"
@@ -159,11 +158,6 @@ function Invoke-MsBuildCompilationForSolution {
 		[Parameter(Mandatory = $True )]
 			[string]$configMode				
 	)
-<<<<<<< HEAD
-=======
-	Write-Warning "Building '$($solutionFile)' in '$($configMode)' mode"
-	$output = & $msbuildPath $solutionFile /t:ReBuild /t:Clean /p:Configuration=$configMode /p:RunOctoPack=true /p:PlatformTarget=AnyCPU /m 2>&1 
->>>>>>> 1c5a212034d7abe7e22cdd1929b403f9cf501d48
 	
 	Write-Verbose "Building '$($solutionFile)' in '$($configMode)' mode"
 	$output = (& $msbuildPath $solutionFile /t:ReBuild /t:Clean /p:Configuration=$configMode /p:RunOctoPack=true /p:PlatformTarget=AnyCPU /m 2>&1) -join "`r`n"
@@ -173,7 +167,7 @@ function Invoke-MsBuildCompilationForSolution {
 		return $output
 	}
 	$VerbosePreference = "Continue"
-	Write-Verbose $output
+	Write-Verbose ($output | Out-String)
 	return
 }
 

--- a/tools/powershell/modules/New-CompiledSolution.psm1
+++ b/tools/powershell/modules/New-CompiledSolution.psm1
@@ -42,6 +42,10 @@ function New-CompiledSolution{
 			)			
 	Begin {
 			$DebugPreference = "Continue"
+			if (-not $PSBoundParameters.ContainsKey('Verbose'))
+			{
+			$VerbosePreference = $PSCmdlet.GetVariableValue('VerbosePreference')
+			}
 		}	
 	Process {
 				Try 
@@ -141,9 +145,10 @@ function Restore-SolutionNuGetPackages {
 	{
 		return $err
 	}
-	
+
 	#As we've re-directed error output to standard output (stdout) using '2>&1', so that we can save it to a variable, we have effectively suppressed stdout, therefore we write $output to the Verbose stream here. 
-	Write-Verbose $output
+	$VerbosePreference = "Continue"
+	Write-Verbose ($output | Out-String)
 	return
 }
 
@@ -154,16 +159,16 @@ function Invoke-MsBuildCompilationForSolution {
 		[Parameter(Mandatory = $True )]
 			[string]$configMode				
 	)
-
+	
 	Write-Verbose "Building '$($solutionFile)' in '$($configMode)' mode"
-	$output = (& $msbuildPath $solutionFile /t:ReBuild /t:Clean /p:Configuration=$configMode /p:PlatformTarget=AnyCPU /m 2>&1) -join "`r`n"
+	$output = (& $msbuildPath $solutionFile /t:ReBuild /t:Clean /p:Configuration=$configMode /p:RunOctoPack=true /p:PlatformTarget=AnyCPU /m 2>&1) -join "`r`n"
 	
 	if ($LASTEXITCODE -eq 1)
 	{
 		return $output
 	}
-
-	Write-Warning $output
+	$VerbosePreference = "Continue"
+	Write-Verbose $output
 	return
 }
 


### PR DESCRIPTION
Fixes for #31 and #24. 
This started as testing the OctoPack addition. If you are using OctoPack within your solution OneBuild will execute it, however output is *NOT* directed to the standard OneBuild \BuildOutput folder as of yet. 

Testing this feature also smoked out some issues with #24 which required some minor fixes around output stream merging that was causing unnecessary errors in the New-CompiledSolution module.