### PR TITLE
Added AssemblyInfo.vb to the include filter for finding files to modify ...

### DIFF
--- a/tools/powershell/modules/Set-BuildNumberWithGitCommitDetail.psm1
+++ b/tools/powershell/modules/Set-BuildNumberWithGitCommitDetail.psm1
@@ -108,7 +108,7 @@ function Set-BuildNumberWithGitCommitDetail{
 
 				#Enumerate through all AssemblyInfo.cs files, updating the AssemblyVersion, AssemblyFileVersion and AssemblyInformationalVersion accordingly, 
 				#this is subsequently reverted within Invoke-CompileSolution once the compilation is complete.
-				$assemblyInfoFiles = Get-ChildItem $gitRepoPath -recurse -include AssemblyInfo.cs
+				$assemblyInfoFiles = Get-ChildItem $gitRepoPath -recurse -include AssemblyInfo.cs,AssemblyInfo.vb
 				ForEach ($assemblyInfoFile in $assemblyInfoFiles)
 				{
 					Try	{


### PR DESCRIPTION
Fix for issue #42 Support VB Projects. This is simply adding AssemblyInfo.vb files to the filter when the files to change list is created.